### PR TITLE
Add authentication with SSO functionality for some services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,10 @@ services:
       ## Services - API
       - traefik.http.routers.traefik.service=api@internal
       ## Middlewares
-#      - traefik.http.middlewares.auth.forwardauth.address=http://viens.ml/api/?v2/auth&group=1
-#      - traefik.http.routers.traefik.middlewares=auth
       - traefik.http.middlewares.secure-headers-frame-options.headers.customFrameOptionsValue="allow-from https:$DOMAINNAME"
-      - traefik.http.middlewares.chain-all.chain.middlewares=chain-auth@file,secure-headers-frame-options
-      - traefik.http.routers.traefik.middlewares=chain-all
+      - traefik.http.middlewares.chain-all-auth.chain.middlewares=chain-auth@file,secure-headers-frame-options
+      - traefik.http.middlewares.chain-all-no-auth.chain.middlewares=chain-no-auth@file,secure-headers-frame-options
+      - traefik.http.routers.traefik.middlewares=chain-all-auth
 
   openldap:
     container_name: openldap
@@ -104,6 +103,7 @@ services:
       - traefik.http.routers.lum.rule=Host(`lm.$DOMAINNAME`)
       - traefik.http.routers.lum.tls=true
       - traefik.http.services.lum.loadbalancer.server.port=80
+      - traefik.http.routers.lum.middlewares=chain-all-auth
 
   keycloak:
     container_name: keycloak
@@ -112,6 +112,7 @@ services:
     depends_on:
       - traefik
       - keycloak-db
+      - openldap
     networks:
       - internal
       - proxy
@@ -148,6 +149,33 @@ services:
     volumes:
       - $CONFIG_PATH/keycloak/database:/var/lib/mysql
 
+  auth:
+    container_name: auth
+    image: thomseddon/traefik-forward-auth
+    restart: unless-stopped
+    depends_on:
+      - traefik
+      - keycloak
+    networks:
+      - internal
+      - proxy
+    environment:
+      - TZ=$TZ
+      - DEFAULT_PROVIDER=oidc
+      - PROVIDERS_OIDC_CLIENT_ID=$KEYCLOAK_CLIENT_ID
+      - PROVIDERS_OIDC_CLIENT_SECRET=$KEYCLOAK_CLIENT_SEC
+      - PROVIDERS_OIDC_ISSUER_URL=https://kc.$DOMAINNAME/auth/realms/$KEYCLOAK_REALM
+      - SECRET=$KEYCLOAK_COOKIE_SEC
+      - AUTH_HOST=auth.$DOMAINNAME
+      - COOKIE_DOMAIN=$DOMAINNAME
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.auth.entrypoints=https
+      - traefik.http.routers.auth.rule=Host(`auth.$DOMAINNAME`)
+      - traefik.http.services.auth.loadbalancer.server.port=4181
+      - traefik.http.routers.auth.tls=true
+      - traefik.http.routers.auth.middlewares=chain-all-auth
+
   organizr:
     container_name: organizr
     image: organizrtools/organizr-v2
@@ -168,7 +196,7 @@ services:
       - traefik.http.routers.organizr.entrypoints=https
       - traefik.http.routers.organizr.rule=Host(`$DOMAINNAME`,`www.$DOMAINNAME`)
       - traefik.http.routers.organizr.tls=true
-      - traefik.http.routers.organizr.middlewares=chain-all
+      - traefik.http.routers.organizr.middlewares=chain-all-auth
 
   jellyfin:
     container_name: jellyfin
@@ -191,8 +219,8 @@ services:
       - traefik.http.routers.jellyfin.entrypoints=https
       - traefik.http.routers.jellyfin.rule=Host(`jf.$DOMAINNAME`)
       - traefik.http.routers.jellyfin.tls=true
-#      - traefik.http.routers.jellyfin.middlewares=auth
       - traefik.http.services.jellyfin.loadbalancer.server.port=8096
+      - traefik.http.routers.jellyfin.middlewares=chain-all-auth
 
   qbittorent:
     container_name: qbittorrent
@@ -216,8 +244,8 @@ services:
       - traefik.http.routers.torrent.entrypoints=https
       - traefik.http.routers.torrent.rule=Host(`qb.$DOMAINNAME`)
       - traefik.http.routers.torrent.tls=true
-#      - traefik.http.routers.torrent.middlewares=auth
       - traefik.http.services.torrent.loadbalancer.server.port=8080
+      - traefik.http.routers.torrent.middlewares=chain-all-auth
 
   jackett:
     container_name: jackett
@@ -237,3 +265,4 @@ services:
       - traefik.http.routers.jackett.entrypoints=https
       - traefik.http.routers.jackett.rule=Host(`jk.$DOMAINNAME`)
       - traefik.http.routers.jackett.tls=true
+      - traefik.http.routers.jackett.middlewares=chain-all-auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,9 @@ services:
     depends_on:
       - traefik
       - keycloak-db
+    networks:
+      - internal
+      - proxy
     environment:
       - TZ=$TZ
       - DB_VENDOR=mysql
@@ -78,9 +81,6 @@ services:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=$KEYCLOAK_PWD
       - PROXY_ADDRESS_FORWARDING=true
-    networks:
-      - internal
-      - proxy
     labels:
       - traefik.enable=true
       - traefik.http.routers.keycloak.entrypoints=https
@@ -93,14 +93,14 @@ services:
     image: mysql
     restart: unless-stopped
     command: --default-time-zone=Europe/Riga
+    networks:
+      - internal
     environment:
       - TZ=$TZ
       - MYSQL_ROOT_PASSWORD=$KEYCLOAK_PWD_DB_ROOT
       - MYSQL_DATABASE=keycloak
       - MYSQL_USER=keycloak
       - MYSQL_PASSWORD=$KEYCLOAK_PWD_DB
-    networks:
-      - internal
     volumes:
       - $CONFIG_PATH/keycloak/database:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=$KEYCLOAK_PWD
       - PROXY_ADDRESS_FORWARDING=true
-      - KEYCLOAK_HOSTNAME=kc.$DOMAINNAME
     networks:
       - internal
       - proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,50 @@ services:
       - traefik.http.middlewares.chain-all.chain.middlewares=chain-auth@file,secure-headers-frame-options
       - traefik.http.routers.traefik.middlewares=chain-all
 
+  keycloak:
+    container_name: keycloak
+    image: jboss/keycloak
+    restart: unless-stopped
+    depends_on:
+      - traefik
+      - keycloak-db
+    environment:
+      - TZ=$TZ
+      - DB_VENDOR=mysql
+      - DB_DATABASE=keycloak
+      - DB_ADDR=keycloak-db
+      - DB_USER=keycloak
+      - DB_PASSWORD=$KEYCLOAK_PWD_DB
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=$KEYCLOAK_PWD
+      - PROXY_ADDRESS_FORWARDING=true
+      - KEYCLOAK_HOSTNAME=kc.$DOMAINNAME
+    networks:
+      - internal
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.keycloak.entrypoints=https
+      - traefik.http.routers.keycloak.rule=Host(`kc.$DOMAINNAME`)
+      - traefik.http.routers.keycloak.tls=true
+      - traefik.http.services.keycloak.loadbalancer.server.port=8080
+
+  keycloak-db:
+    container_name: keycloak-db
+    image: mysql
+    restart: unless-stopped
+    command: --default-time-zone=Europe/Riga
+    environment:
+      - TZ=$TZ
+      - MYSQL_ROOT_PASSWORD=$KEYCLOAK_PWD_DB_ROOT
+      - MYSQL_DATABASE=keycloak
+      - MYSQL_USER=keycloak
+      - MYSQL_PASSWORD=$KEYCLOAK_PWD_DB
+    networks:
+      - internal
+    volumes:
+      - $CONFIG_PATH/keycloak/database:/var/lib/mysql
+
   organizr:
     container_name: organizr
     image: organizrtools/organizr-v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,50 @@ services:
       - traefik.http.middlewares.chain-all.chain.middlewares=chain-auth@file,secure-headers-frame-options
       - traefik.http.routers.traefik.middlewares=chain-all
 
+  openldap:
+    container_name: openldap
+    image: osixia/openldap
+    restart: unless-stopped
+    networks:
+      - internal
+    environment:
+      - TZ=$TZ
+      - LDAP_DOMAIN=$DOMAINNAME
+      - LDAP_BASE_DN=$LDAP_BASE_DN
+      - LDAP_ORGANISATION=Dockeria
+      - LDAP_ADMIN_PASSWORD=$LDAP_ADMIN_PWD
+      - LDAP_TLS=false
+      - LDAP_RFC2307BIS_SCHEMA=true
+    volumes:
+    - $CONFIG_PATH/openldap/runtime:/var/lib/ldap
+    - $CONFIG_PATH/openldap/static:/etc/ldap/slapd.d
+
+  lum:
+    container_name: lum
+    image: wheelybird/ldap-user-manager
+    restart: unless-stopped
+    depends_on:
+      - traefik
+      - openldap
+    networks:
+      - internal
+      - proxy
+    environment:
+      - TZ=$TZ
+      - SERVER_HOSTNAME=lm.$DOMAINNAME
+      - LDAP_URI=ldap://openldap
+      - LDAP_BASE_DN=$LDAP_BASE_DN
+      - LDAP_ADMIN_BIND_DN=cn=admin,$LDAP_BASE_DN
+      - LDAP_ADMIN_BIND_PWD=$LDAP_ADMIN_PWD
+      - LDAP_ADMINS_GROUP=admins
+      - NO_HTTPS=true
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.lum.entrypoints=https
+      - traefik.http.routers.lum.rule=Host(`lm.$DOMAINNAME`)
+      - traefik.http.routers.lum.tls=true
+      - traefik.http.services.lum.loadbalancer.server.port=80
+
   keycloak:
     container_name: keycloak
     image: jboss/keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,32 +78,28 @@ services:
     - $CONFIG_PATH/openldap/runtime:/var/lib/ldap
     - $CONFIG_PATH/openldap/static:/etc/ldap/slapd.d
 
-  lum:
-    container_name: lum
-    image: wheelybird/ldap-user-manager
+  phpldapadmin:
+    container_name: phpldapadmin
+    image: osixia/phpldapadmin
     restart: unless-stopped
     depends_on:
-      - traefik
       - openldap
     networks:
       - internal
       - proxy
     environment:
       - TZ=$TZ
-      - SERVER_HOSTNAME=lm.$DOMAINNAME
-      - LDAP_URI=ldap://openldap
-      - LDAP_BASE_DN=$LDAP_BASE_DN
-      - LDAP_ADMIN_BIND_DN=cn=admin,$LDAP_BASE_DN
-      - LDAP_ADMIN_BIND_PWD=$LDAP_ADMIN_PWD
-      - LDAP_ADMINS_GROUP=admins
-      - NO_HTTPS=true
+      - PHPLDAPADMIN_LDAP_HOSTS=openldap
+      - PHPLDAPADMIN_HTTPS=false
+      - PHPLDAPADMIN_TRUST_PROXY_SSL=true
+      - PHPLDAPADMIN_LDAP_CLIENT_TLS=false
     labels:
       - traefik.enable=true
-      - traefik.http.routers.lum.entrypoints=https
-      - traefik.http.routers.lum.rule=Host(`lm.$DOMAINNAME`)
-      - traefik.http.routers.lum.tls=true
-      - traefik.http.services.lum.loadbalancer.server.port=80
-      - traefik.http.routers.lum.middlewares=chain-all-auth
+      - traefik.http.routers.ldapadmin.entrypoints=https
+      - traefik.http.routers.ldapadmin.rule=Host(`pl.$DOMAINNAME`)
+      - traefik.http.routers.ldapadmin.tls=true
+#      - traefik.http.services.ldapadmin.loadbalancer.server.port=8080
+      - traefik.http.routers.ldapadmin.middlewares=chain-all-auth
 
   keycloak:
     container_name: keycloak

--- a/traefik/rules/middlewares.yml
+++ b/traefik/rules/middlewares.yml
@@ -4,6 +4,7 @@ http:
       rateLimit:
         average: 100
         burst: 50
+
     secure-headers:
       headers:
         accessControlAllowMethods:
@@ -27,8 +28,21 @@ http:
           X-Robots-Tag: "none,noarchive,nosnippet,notranslate,noimageindex,"
           server: ""
 
+    keycloak:
+      forwardAuth:
+        address: "http://auth:4181"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - "X-Forwarded-User"
+
+    chain-no-auth:
+      chain:
+        middlewares:
+          - rate-limit
+          - secure-headers
     chain-auth:
       chain:
         middlewares:
           - rate-limit
           - secure-headers
+          - keycloak


### PR DESCRIPTION
User info is stored in an OpenLDAP container, which should be managed by phpLDAPadmin in a seperate container (this currently does not work because #1).
The authentication process is governed by a container with keycloak (another container "keycloak-db" is an instance of mysql (because #3) containing data necessary for operation) with a connection to the OpenLDAP service and an OIDC client that can be used to authenticate users with [thomseddon/traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth) connected to the Traefik proxy with a forwardAuth middleware.
Some services (like Organizr) can use X-Forwarded-User for SSO, but for most services I can disable the need for logins (except Jellyfin).
